### PR TITLE
fix outbound-tls-golang client reading

### DIFF
--- a/additions/outbound-tls-golang/main.go
+++ b/additions/outbound-tls-golang/main.go
@@ -59,8 +59,13 @@ func main() {
 			fmt.Println(err)
 			continue
 		}
-		defer res.Body.Close()
+		_, err = io.ReadAll(res.Body)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
 		fmt.Printf("res: %+v\n", res)
+		res.Body.Close()
 
 		req, err = http.NewRequest("GET", "https://gorest.co.in/public/v2/users", nil)
 		if err != nil {
@@ -74,8 +79,13 @@ func main() {
 			fmt.Println(err)
 			continue
 		}
-		defer res.Body.Close()
+		_, err = io.ReadAll(res.Body)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
 		fmt.Printf("res: %+v\n", res)
+		res.Body.Close()
 
 		req, err = http.NewRequest("GET", "https://gorest.co.in/public/v2/posts", nil)
 		if err != nil {
@@ -89,12 +99,17 @@ func main() {
 			fmt.Println(err)
 			continue
 		}
-		defer res.Body.Close()
-		fmt.Printf("res: %+v\n", res)
+		_, err = io.ReadAll(res.Body)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
 		_, err = io.ReadAll(res.Body)
 		if err != nil {
 			fmt.Println(err)
 		}
+		fmt.Printf("res: %+v\n", res)
+		res.Body.Close()
 
 		time.Sleep(3 * time.Second)
 	}

--- a/additions/outbound-tls-golang/main.go
+++ b/additions/outbound-tls-golang/main.go
@@ -41,8 +41,13 @@ func main() {
 			fmt.Println(err)
 			continue
 		}
-		defer res.Body.Close()
+		_, err = io.ReadAll(res.Body)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
 		fmt.Printf("res: %+v\n", res)
+		res.Body.Close()
 
 		payload := strings.NewReader(fmt.Sprintf("------WebKitFormBoundary7MA4YWxkTrZu0gW\r\nContent-Disposition: form-data; name=\"email\"\r\n\r\njohn.doe.%d@example.com\r\n------WebKitFormBoundary7MA4YWxkTrZu0gW\r\nContent-Disposition: form-data; name=\"name\"\r\n\r\nJohn\r\n------WebKitFormBoundary7MA4YWxkTrZu0gW\r\nContent-Disposition: form-data; name=\"gender\"\r\n\r\nmale\r\n------WebKitFormBoundary7MA4YWxkTrZu0gW\r\nContent-Disposition: form-data; name=\"status\"\r\n\r\nactive\r\n------WebKitFormBoundary7MA4YWxkTrZu0gW--", j))
 		req, err = http.NewRequest("POST", "https://gorest.co.in/public/v2/users", payload)


### PR DESCRIPTION
outbound-tls-golang client did not read full HTTP body before making new request, in this case it performs only partial traffic reading from the server

This issue in one of root cause of the https://github.com/kubeshark/tracer/issues/29

maybe other clients need to be fixed as well